### PR TITLE
Fix false OK validations for configuration with additional properties

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -218,6 +218,18 @@ func TestValidate(t *testing.T) {
 			recursive:        false,
 			expectedResults:  []validate.ValidationResult{},
 		},
+		{
+			name:             "test additional properties",
+			filenames:        []string{"testdata/manifests/deployment_additional_properties.yaml"},
+			schema:           "testdata/schemas/k8s-1.17.0.json",
+			crds:             []string{},
+			expectedExitCode: 1,
+			recursive:        false,
+			expectedResults: []validate.ValidationResult{
+				{Message: "valid", Severity: "OK", Name: "test", Namespace: "default", Kind: "v1/ConfigMap"},
+				{Message: "Error at \"/spec/template/spec\":Property 'unexpectedAdditionalProperty' is unsupported", Severity: "ERROR", Name: "some-app-envoy", Namespace: "example", Kind: "apps/v1/Deployment"},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/testdata/manifests/deployment_additional_properties.yaml
+++ b/cmd/testdata/manifests/deployment_additional_properties.yaml
@@ -1,0 +1,32 @@
+---
+# ConfigMap allows additional properties
+kind: ConfigMap
+metadata:
+  name: test
+  namespace: default
+
+apiVersion: v1
+data:
+  akey: avalue
+  anotherkey: anothervalue
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: some-app-envoy
+  namespace: example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: some-app-envoy
+  template:
+    metadata:
+      labels:
+        app: some-app-envoy
+    spec:
+      # test an unexpected property
+      unexpectedAdditionalProperty: 0
+      containers:
+      - image: envoyproxy/envoy:v1.13.1
+        name: envoy

--- a/pkg/validate/openapi_validator.go
+++ b/pkg/validate/openapi_validator.go
@@ -62,6 +62,13 @@ func NewOpenApi2Validator(openApi2SpecsBytes []byte) (*OpenApiValidator, error) 
 	}
 	*/
 
+	additionalPropertiesAllowed := false
+	for _, schema := range swagger3.Components.Schemas {
+		if schema.Value.AdditionalPropertiesAllowed == nil {
+			schema.Value.AdditionalPropertiesAllowed = &additionalPropertiesAllowed
+		}
+	}
+
 	// build schemaCache:
 	schemaCache, err := buildSchemaCache(swagger3)
 


### PR DESCRIPTION
I found a bug when validating configuration with unexpected properties (they can happen easily if you have a wrong indent for a field such such as volumeMounts or any other:

```
➜  scheriff -s <(k get --raw /openapi/v2) -f deploy.yaml

Validating config in deploy.yaml against schema in /dev/fd/11
Results:
Validating manifests in deploy.yaml:
         - OK, truffle-networks (v1/ConfigMap): valid
         - OK, truffle-deploy (batch/v1/Job): valid


➜  kubectl apply -f deploy.yaml

configmap/truffle-networks created
error: error validating "deploy.yaml": error validating data: [ValidationError(Job.spec.template.spec): unknown field "volumeMounts" in io.k8s.api.core.v1.PodSpec, ValidationError(Job.spec.template): unknown field "volumes" in io.k8s.api.core.v1.PodTemplateSpec]; if you choose to ignore these errors, turn validation off with --validate=false
```