### PR TITLE
Fix nullable fields validation

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -128,7 +128,7 @@ func TestValidate(t *testing.T) {
 			crds:             []string{},
 			expectedExitCode: 1,
 			recursive:        false,
-			strict:			  true,
+			strict:           true,
 			expectedResults: []validate.ValidationResult{
 				{"Kind 'example.io/v1/UnknownCRD' not found in schema", validate.SeverityWarning, "example-unknown-kind", "example", "example.io/v1/UnknownCRD"},
 			},
@@ -153,7 +153,7 @@ func TestValidate(t *testing.T) {
 			crds:             []string{},
 			expectedExitCode: 1,
 			recursive:        false,
-			strict:			  true,
+			strict:           true,
 			expectedResults: []validate.ValidationResult{
 				{"Kind 'example.io/v1/UnknownCRD' not found in schema", validate.SeverityWarning, "example-unknown-kind", "example", "example.io/v1/UnknownCRD"},
 				{"Error parsing k8s resource from document 0: error converting YAML to JSON: yaml: line 3: mapping values are not allowed in this context\n", validate.SeverityError, "", "", ""},
@@ -303,7 +303,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name:             "test additional properties",
-			filenames:        []string{"testdata/manifests/deployment_additional_properties.yaml"},
+			filenames:        []string{"testdata/manifests/deployment_additional_properties.yaml", "testdata/manifests/cm_managed_fields.yaml"},
 			schema:           "testdata/schemas/k8s-1.17.0.json",
 			crds:             []string{},
 			expectedExitCode: 1,
@@ -311,6 +311,7 @@ func TestValidate(t *testing.T) {
 			expectedResults: []validate.ValidationResult{
 				{Message: "valid", Severity: "OK", Name: "test", Namespace: "default", Kind: "v1/ConfigMap"},
 				{Message: "Error at \"/spec/template/spec\":Property 'unexpectedAdditionalProperty' is unsupported", Severity: "ERROR", Name: "some-app-envoy", Namespace: "example", Kind: "apps/v1/Deployment"},
+				{Message: "valid", Severity: "OK", Name: "test-cm", Namespace: "default", Kind: "v1/ConfigMap"},
 			},
 		},
 		{

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -313,6 +313,17 @@ func TestValidate(t *testing.T) {
 				{Message: "Error at \"/spec/template/spec\":Property 'unexpectedAdditionalProperty' is unsupported", Severity: "ERROR", Name: "some-app-envoy", Namespace: "example", Kind: "apps/v1/Deployment"},
 			},
 		},
+		{
+			name:             "test nullable properties",
+			filenames:        []string{"testdata/manifests/ns_nullable_field.yaml"},
+			schema:           "testdata/schemas/k8s-1.17.0.json",
+			crds:             []string{},
+			expectedExitCode: 0,
+			recursive:        false,
+			expectedResults: []validate.ValidationResult{
+				{Message: "valid", Severity: "OK", Name: "test", Namespace: "", Kind: "v1/Namespace"},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/testdata/manifests/cm_managed_fields.yaml
+++ b/cmd/testdata/manifests/cm_managed_fields.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+  namespace: default
+  labels:
+    test-label: test
+  managedFields:
+  - manager: kubectl
+    operation: Apply
+    apiVersion: v1
+    time: "2010-10-10T00:00:00Z"
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          f:test-label: {}
+      f:data:
+        f:key: {}
+data:
+  key: some value

--- a/cmd/testdata/manifests/ns_nullable_field.yaml
+++ b/cmd/testdata/manifests/ns_nullable_field.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: test

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -2,6 +2,7 @@ package utils
 
 import "strings"
 
+// JoinNotEmptyStrings joins strings in `elem` using `sep` as a separator, ignoring the empty strings
 func JoinNotEmptyStrings(sep string, elem ...string) string {
 	tokens := make([]string, 0)
 	for _, s := range elem {
@@ -12,7 +13,8 @@ func JoinNotEmptyStrings(sep string, elem ...string) string {
 	return strings.Join(tokens, sep)
 }
 
-func IndexOf(elem string, slice ...string) int {
+// StringSliceIndexOf returns the index of an element in a string slice. If the slice doesn't contain the element, it will return -1
+func StringSliceIndexOf(slice []string, elem string) int {
 	for i, s := range slice {
 		if s == elem {
 			return i

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -11,3 +11,12 @@ func JoinNotEmptyStrings(sep string, elem ...string) string {
 	}
 	return strings.Join(tokens, sep)
 }
+
+func IndexOf(elem string, slice ...string) int {
+	for i, s := range slice {
+		if s == elem {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/validate/openapi_validator.go
+++ b/pkg/validate/openapi_validator.go
@@ -85,7 +85,7 @@ func adaptSpecsToKubernetesValidation(swagger3 *openapi3.Swagger) {
 	additionalPropertiesAllowed := false
 	for _, schema := range swagger3.Components.Schemas {
 		// Kubernetes doesn't accept additional properties by default
-		if schema.Value.AdditionalPropertiesAllowed == nil {
+		if schema.Value.AdditionalPropertiesAllowed == nil && len(schema.Value.Properties) > 0 {
 			schema.Value.AdditionalPropertiesAllowed = &additionalPropertiesAllowed
 		}
 		// Kubernetes accepts `null` for non-required properties

--- a/pkg/validate/openapi_validator.go
+++ b/pkg/validate/openapi_validator.go
@@ -67,6 +67,14 @@ func NewOpenApi2Validator(openApi2SpecsBytes []byte) (*OpenApiValidator, error) 
 		if schema.Value.AdditionalPropertiesAllowed == nil {
 			schema.Value.AdditionalPropertiesAllowed = &additionalPropertiesAllowed
 		}
+		// Kubernetes accepts `null` for non-required properties
+		for propertyName, property := range schema.Value.Properties {
+			if utils.IndexOf(propertyName, schema.Value.Required...) >= 0 {
+				property.Value.Nullable = false
+			} else {
+				property.Value.Nullable = true
+			}
+		}
 	}
 
 	// build schemaCache:


### PR DESCRIPTION
Fixes #12 

Also fixes: "unsupported property" for `type: object` fields (ie: FieldsV1 inside metadata.managedFields)