### PR TITLE
Fix validating files without yaml extension (like in process substitution)

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -325,6 +325,17 @@ func TestValidate(t *testing.T) {
 				{Message: "valid", Severity: "OK", Name: "test", Namespace: "", Kind: "v1/Namespace"},
 			},
 		},
+		{
+			name:             "test validating input files without yaml/yml extension",
+			filenames:        []string{"testdata/manifests/non_yaml_extension.txt"},
+			schema:           "testdata/schemas/k8s-1.17.0.json",
+			crds:             []string{},
+			expectedExitCode: 0,
+			recursive:        false,
+			expectedResults: []validate.ValidationResult{
+				{Message: "valid", Severity: "OK", Name: "test-cm", Namespace: "default", Kind: "v1/ConfigMap"},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/testdata/manifests/non_yaml_extension.txt
+++ b/cmd/testdata/manifests/non_yaml_extension.txt
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+  namespace: default
+  labels:
+    test-label: test
+data:
+  key: some value

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -10,7 +10,10 @@ import (
 type FileFunc func(filename string) error
 type FileNameFilter func(filename string) bool
 
-// ApplyToPathWithFilter executes a 'FileFunc' function for each file in a given 'path'. If 'path' is a regular file itself 'FileFunc' will be applied to it directly. If 'path' is a folder, the function will be applied to each regular file inside the folder. This behaviour can be made recursive by setting 'recursive' to true.
+// ApplyToPathWithFilter executes a 'FileFunc' function for each file in a given 'path'.
+// If 'path' is a regular file itself 'FileFunc' will be applied to it directly without filtering.
+// If 'path' is a folder, the function will be applied to each regular file inside the folder that matches the `FileNameFilter`.
+// This behaviour can be made recursive by setting 'recursive' to true.
 func ApplyToPathWithFilter(path string, recursive bool, function FileFunc, filter FileNameFilter) error {
 	fileInfo, err := os.Stat(path)
 	if err != nil {
@@ -21,7 +24,7 @@ func ApplyToPathWithFilter(path string, recursive bool, function FileFunc, filte
 		return ApplyToFolder(path, recursive, function, filter)
 	}
 
-	return ApplyToFile(path, function, filter)
+	return ApplyToFile(path, function, nil)
 }
 
 func ApplyToFile(path string, function FileFunc, filter FileNameFilter) error {


### PR DESCRIPTION
When using the -f option on a file that is not .yaml or .yml. For
instance this is the case when using process substitution, this is now allowed:
```bash
scheriff -s path/to/newer/k8s/specs.json  -f <(k get deployment mydeploy -o yaml)
```